### PR TITLE
Add the ability to load MIB Files, a MIB Dir, and handle the required trend duration for non-numeric value types.

### DIFF
--- a/mib2zabbix.pl
+++ b/mib2zabbix.pl
@@ -23,7 +23,7 @@ Export loaded SNMP MIB OIDs to Zabbix Template XML
     -v, --snmpver=1|2|3         SNMP version (default: 2)
     -p, --port=PORT             SNMP UDP port number (default: 161)
 
-    -d, --mibdir=MIBDIR		Additional MIB directory to include
+    -d, --mibdir=MIBDIR         Additional MIB directory to include
     -F, --mibfile=MIBFILE       Additional MIB file to include
 
 SNMP Version 1 or 2c specific
@@ -78,6 +78,7 @@ http://www.webnms.com/snmp/help/snmpapi/snmpv3/table_handling/snmptables_basics.
 
 use strict;
 #use warnings;
+no warnings 'experimental::smartmatch';
 
 use Cwd 'abs_path';
 use Data::Dumper;
@@ -176,8 +177,8 @@ my $snmpv3_sec_protocol_map = {
 
 # Default command line options
 my $opts =  {
-    delay               => 60,              # 1 minute check interval
-    disc_delay          => 3600,            # Hourly discovery
+    delay               => '1m',                # 1 minute check interval
+    disc_delay          => '1h',            # Hourly discovery
     enableitems         => 0,               # Disable items
     group               => 'Templates',
     history             => 7,
@@ -229,8 +230,8 @@ GetOptions(
     'x|privacy=s'           => \$opts->{ v3sec_protocol },  # SNMPv3 Privacy protocol
     'X|privpass=s'          => \$opts->{ v2sec_pass},       # SNMPv3 Privacy passphrase
 
-    'check-delay=i'         => \$opts->{ delay },           # Update interval in seconds
-    'disc-delay=i'          => \$opts->{ disc_delay },      # Update interval in seconds
+    'check-delay=s'         => \$opts->{ delay },           # Update interval in seconds
+    'disc-delay=s'          => \$opts->{ disc_delay },      # Update interval in seconds
     'history=i'             => \$opts->{ history },         # History retention in days
     'trends=i'              => \$opts->{ trends },          # Trends retention in days
 
@@ -476,9 +477,9 @@ sub node_to_item {
         if (!defined($item->{ value_type })) {
             print STDERR "No type mapping found for type $node->{ type } in $node->{ objectID }\n";
         }
-	if ( $item->{ value_type } =~ '4' ) {
-	    $item->{ trends } = 0;
-	}
+        if ( $item->{ value_type } =~ '4' ) {
+            $item->{ trends } = 0;
+        }
     }
 
     # Set storage type to Delta for MIB counter types
@@ -520,7 +521,7 @@ sub node_to_item {
 
         # add template value map
         $valuemaps->{ $map_name }->{ 'mappings' } = [];
-        foreach(keys %{ $node->{ enums } }) {
+        foreach(sort keys %{ $node->{ enums } }) {
             push(@{ $valuemaps->{ $map_name }->{ 'mappings' } }, {
                 'value'     => $node->{ enums }->{ $_ },
                 'newvalue'  => $_
@@ -802,11 +803,7 @@ sub build_template {
             } else {
                 # Remove unrequired fields
                 delete($disc_rule->{ applications });
-                # If passed load specified mib directory
-                &SNMP::addMibDirs( $opts->{ mibdir } );
-                # If passed load specified mib file
-                &SNMP::addMibFiles( $opts->{ mibfile } );
-                SNMP::initMib();delete($disc_rule->{ data_type });
+                delete($disc_rule->{ data_type });
 
                 # Create new array for prototypes
                 $disc_rule->{ item_prototypes } = [];
@@ -894,7 +891,7 @@ if (!$oid_root || $oid_root->{ objectID } ne $opts->{ oid }) {
     build_template($template, $oid_root, 0);
 
     # Convert applications hash to array
-    @{ $template->{ applications } } = map { { name => $_ } } keys %{ $template->{ apptags } };
+    @{ $template->{ applications } } = map { { name => $_ } } sort keys %{ $template->{ apptags } };
     delete($template->{ apptags });
 
     # Build XML document
@@ -906,8 +903,10 @@ if (!$oid_root || $oid_root->{ objectID } ne $opts->{ oid }) {
         templates   => [$template],
         triggers    => [],
         graphs      => [],
-        value_maps  => [$valuemaps]
     };
+
+    # Only add value_maps section if there are value mappings present.
+    $output->{value_maps} = [$valuemaps] if %{ $valuemaps };
 
     # Output stream
     my $fh = *STDOUT;
@@ -933,7 +932,7 @@ if (!$oid_root || $oid_root->{ objectID } ne $opts->{ oid }) {
             'trigger_prototypes'    => 'trigger_prototype',
             'graph_prototypes'      => 'graph_prototype',
             'host_prototypes'       => 'host_prototype',
-            'value_maps'            => %{ $valuemaps } ? 'value_map' : undef,
+            'value_maps'            => 'value_map',
             'mappings'              => 'mapping'
         }
     );


### PR DESCRIPTION
As part of our work at California Northstate University, we patched this tool with a few quality of live improvements to support our use of building Zabbix templates. 

I handled the enhancement request listed here to load MIB directories or individual MIB files: https://github.com/zabbix-tools/mib2zabbix/issues/7 . 

Additionally, I caught and fixed a template bug where non-numerical value types require a 0 trend history in the later template formats, as indicated here: https://www.zabbix.com/forum/zabbix-help/463160-6-4-0-template-import-failed-invalid-parameter-2-trends?p=463243#post463243 .